### PR TITLE
Corrige o retorno à tela anterior após salvar (Entregas e afins)

### DIFF
--- a/public/common.inc.php
+++ b/public/common.inc.php
@@ -126,6 +126,20 @@ function verifica_seguranca($parametro_validacao = true)
 function redireciona($pagina)
 {
 	// require_once("registro_visita.inc.php");
+	// URL absoluta do PRÓPRIO host (ex.: back_url preenchido com document.referrer):
+	// reduz à forma relativa (pagina.php?query) e deixa a validação abaixo decidir.
+	if (preg_match('#^https?://#i', $pagina))
+	{
+		$u = parse_url($pagina);
+		$host_req = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
+		$host_url = isset($u['host']) ? $u['host'] : '';
+		if (isset($u['port'])) $host_url .= ':' . $u['port'];
+		if ($host_req !== '' && strcasecmp($host_url, $host_req) === 0)
+		{
+			$pagina = basename(isset($u['path']) ? $u['path'] : '');
+			if (isset($u['query']) && $u['query'] !== '') $pagina .= '?' . $u['query'];
+		}
+	}
 	// só permite alvo relativo da app (nome.php?query); bloqueia esquema (http://),
 	// protocol-relative (//) e caracteres perigosos — fecha open-redirect via back_url.
 	if (!preg_match('#^[A-Za-z0-9_-]+\.php(\?[^\s\'"<>]*)?$#', $pagina))


### PR DESCRIPTION
## Problema

Depois da atualização de segurança de junho (#17), salvar em telas como as de Entregas passou a levar o usuário de volta à página inicial, em vez de retornar à tela em que estava. Quem lançava entregas precisava refazer o caminho inteiro a cada salvamento.

## Causa

Sete telas (entrega_cestante, entrega_cestante_incluir, entrega_nucleo, entrega_divergencia_justificativa, financas_prazo, distribuicao, distribuicao_por_produtor) preenchem o campo `back_url` com `document.referrer`, que é sempre uma **URL absoluta**. A validação de redirecionamento introduzida no #17 aceita apenas alvos relativos (`pagina.php?query`), então o alvo era rejeitado e caía no fallback (página inicial).

## Correção

Em `redireciona()`: quando o alvo é uma URL absoluta **do próprio host** (host e porta conferidos com a requisição), ela é reduzida à forma relativa (`pagina.php?query`) e passa pela **mesma validação estrita** de antes. URLs de outros hosts continuam bloqueadas — a proteção contra redirecionamento externo permanece igual; apenas deixamos de rejeitar o próprio sistema.

Uma mudança em um único ponto corrige as sete telas, sem alterar formulários ou JavaScript.

## Verificação

- Matriz de casos (alvo próprio absoluto/relativo, host estranho, protocol-relative, vazio, porta divergente) nas duas versões de PHP do ambiente local — todos os casos passam.
- Salvamento real de ponta a ponta com `back_url` absoluto → retorna à tela de origem.
- Smoke completo verde nas duas versões de PHP.
- Verificado em produção após o deploy: salvar em Entregas retorna à tela anterior.